### PR TITLE
badgerstore: implement the blob.StoreCloser interface

### DIFF
--- a/badgerstore_test.go
+++ b/badgerstore_test.go
@@ -17,7 +17,6 @@ package badgerstore_test
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -27,36 +26,43 @@ import (
 	badger "github.com/dgraph-io/badger/v4"
 )
 
-func TestStore(t *testing.T) {
+func TestOpener(t *testing.T) {
 	dir := t.TempDir()
+	ctx := context.Background()
 
-	t.Logf("Test store: %s", dir)
-	s, err := badgerstore.Opener(context.Background(), dir+"?auto_sync=1")
+	s, err := badgerstore.Opener(ctx, dir+"?auto_sync=1")
 	if err != nil {
 		t.Fatalf("Creating store in %q: %v", dir, err)
 	}
-	storetest.Run(t, s)
-	if err := s.Close(context.Background()); err != nil {
+
+	t.Run("Root", func(t *testing.T) {
+		storetest.Run(t, storetest.NopCloser(s))
+	})
+
+	t.Run("Sub", func(t *testing.T) {
+		sub, err := s.Sub(ctx, "alt")
+		if err != nil {
+			t.Fatalf("Open substore: %v", err)
+		}
+		storetest.Run(t, storetest.NopCloser(sub))
+	})
+
+	if err := s.Close(ctx); err != nil {
 		t.Errorf("Closing store: %v", err)
 	}
 }
 
 func TestKeyPrefix(t *testing.T) {
-	dir, err := os.MkdirTemp("", "fafoprefix")
-	if err != nil {
-		t.Fatal(err)
-	}
-	kv, err := badgerstore.NewKV(badgerstore.Options{
+	dir := t.TempDir()
+
+	st, err := badgerstore.New(badgerstore.Options{
 		Badger:    badger.DefaultOptions(dir).WithLogger(nil),
 		KeyPrefix: ":wibble:",
 	})
 	if err != nil {
 		t.Fatalf("Creating store in %q: %v", dir, err)
 	}
-	storetest.Run(t, kv)
-	if err := kv.Close(context.Background()); err != nil {
-		t.Errorf("Closing store: %v", err)
-	}
+	storetest.Run(t, st)
 }
 
 func TestListCancel(t *testing.T) {
@@ -68,7 +74,8 @@ func TestListCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Creating store in %q: %v", dir, err)
 	}
-	if err := s.Put(ctx, blob.PutOptions{
+	kv := storetest.SubKeyspace(t, ctx, s, "")
+	if err := kv.Put(ctx, blob.PutOptions{
 		Key:  "test key 1",
 		Data: []byte("ok boomer"),
 	}); err != nil {
@@ -77,15 +84,14 @@ func TestListCancel(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	err = s.List(ctx, "", func(string) error {
+	err = kv.List(ctx, "", func(string) error {
 		time.Sleep(1 * time.Second)
 		return nil
 	})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Wrong error: got %v, want %v", err, context.DeadlineExceeded)
 	}
-
-	if err := s.Close(context.Background()); err != nil {
-		t.Errorf("Closing store: %v", err)
+	if err := kv.(badgerstore.KV).Close(context.Background()); err != nil {
+		t.Errorf("Closing KV: %v", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/creachadair/badgerstore
 
 go 1.23
 
-toolchain go1.23.1
-
 require (
-	github.com/creachadair/ffs v0.7.1
+	github.com/creachadair/ffs v0.7.2-0.20241218195804-ea9c7142ea51
 	golang.org/x/net v0.32.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/creachadair/ffs v0.7.1 h1:Ik0dVegyV1Zf0x9yrtNuwL796rn9Ecy/Dj5GmNIi5so=
-github.com/creachadair/ffs v0.7.1/go.mod h1:PD7OPVlVGEvwg8kAoR8LsqsOFmjo8EERNOEJgtzC4x4=
+github.com/creachadair/ffs v0.7.2-0.20241218195804-ea9c7142ea51 h1:GKwNY26tQRrI+Kjayv2OE640EvJwyjD8oS3NVRzP4hc=
+github.com/creachadair/ffs v0.7.2-0.20241218195804-ea9c7142ea51/go.mod h1:PD7OPVlVGEvwg8kAoR8LsqsOFmjo8EERNOEJgtzC4x4=
 github.com/creachadair/mds v0.22.0 h1:IRm4fWRKF9Pi4k3DEfgdlhMMYVxyef9FFall4r0GP4A=
 github.com/creachadair/mds v0.22.0/go.mod h1:ArfS0vPHoLV/SzuIzoqTEZfoYmac7n9Cj8XPANHocvw=
 github.com/creachadair/taskgroup v0.13.2 h1:3KyqakBuFsm3KkXi/9XIb0QcA8tEzLHLgaoidf0MdVc=


### PR DESCRIPTION
See creachadair/ffs#26

The store partitions the keyspace of the underlying DB by hashing the names of
the path from the root to produce a prefix: At the root, the prefix is "".

N.B.: go.mod patches ffs to commit ea9c7142ea51 for now
